### PR TITLE
ci: create new build GitHub Action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,86 @@
+name: Build website
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+env:
+  BUILD_PATH: "."
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+# This workflow contains two jobs: one to build and another to upload our content to GH Pages
+jobs:
+  # The first job holds responsibility to install deps, build and upload
+  # artifacts from GH container to expose them later
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Here we execute our job, each step represents one phase of our pipeline
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout codebase
+        uses: actions/checkout@v3
+      # Setup our Pages environment to work on later
+      - name: Setup Pages environment
+        id: build_page
+        uses: actions/configure-pages@v3
+      # Setup NodeJS and NPM to build our frontend
+      - name: Setup NodeJS platform
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          # TODO When we have package-lock.json commited this comment can be removed
+          # to enable cache to our pipeline and increase speed
+          # cache: "npm"
+          # cache-dependency-path: ${{ env.BUILD_PATH }}/package-lock.json
+      # Run NPM CI to clean and install dependencies 
+      - name: Install dependencies
+        run: npm install
+        working-directory: ${{ env.BUILD_PATH }}
+      # Builds Astro/Starlight environment with GH Pages settings
+      - name: Build Astro environment
+        working-directory: ${{ env.BUILD_PATH }}
+        run: |
+          npm run build -- \
+          --site "${{ steps.build_page.outputs.origin }}" \
+          --base "${{ steps.build_page.outputs.base_path }}"
+      # Uploads generated artifact to GitHub
+      - name: Upload artifact to GH if preparing to deploy
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ${{ env.BUILD_PATH }}/dist
+
+  deploy_production:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    environment: 
+      name: github-pages
+      url: ${{ steps.prod_deployment.outputs.page_url }}
+    concurrency: 
+      group: "deploy"
+    steps:
+      - name: Upload to GH Production
+        uses: actions/deploy-pages@v2
+        id: prod_deployment


### PR DESCRIPTION
This PR it's part of an effort to configure CI/CD to builds and Pull Requests, as mentioned in #3.

We're introducing a simple GitHub Workflow to build and deploy the website to GitHub Pages. In the future, we can investigate how to deploy on development environments.